### PR TITLE
cppcheck: fix some reports

### DIFF
--- a/vbox.h
+++ b/vbox.h
@@ -354,7 +354,6 @@ void VM::throttle()
         cerr << "INFO: Number of cores: " << n_cpus << endl;
 
         if (aid.project_preferences) {
-                if (!aid.project_preferences) return;
                 double max_vm_cpu_pct = 100.0;
                 if (parse_double(aid.project_preferences, "<max_vm_cpu_pct>", 
                                                                     max_vm_cpu_pct)) {
@@ -412,12 +411,12 @@ bool VM::is_status(string status)
                 output = buffer;
 
                 if (output.find("VMState=\"" + status + "\"") != string::npos) {
-                        return true;
                         boinc_end_critical_section();
+                        return true;
                 }
                 else {
-                        return false;
                         boinc_end_critical_section();
+                        return false;
                 }
         
         }


### PR DESCRIPTION
vbox.h:356] -> [vbox.h:357]: (warning) Opposite conditions in nested 'if' blocks lead to a dead code block.
[vbox.h:416]: (style) Statements following return, break, continue, goto or throw will never be executed.
[vbox.h:420]: (style) Statements following return, break, continue, goto or throw will never be executed.
